### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Publish Docker Image
       id: docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         dockerfile: build/Dockerfile
         name: anchorfree/kafka-ambassador

--- a/.github/workflows/on_push_master.yaml
+++ b/.github/workflows/on_push_master.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Publish Docker Image
       id: docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         dockerfile: build/Dockerfile
         name: anchorfree/kafka-ambassador

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Build and Publish Docker Image
       id: docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         dockerfile: build/Dockerfile
         name: anchorfree/kafka-ambassador


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore